### PR TITLE
Beam upgrade to 2.5.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ ext {
     guavaVersion = '22.0'
     logstashVersion = '4.11'
     logbackVersion = '1.2.3'
-    beamVersion = '2.2.0'
+    beamVersion = '2.5.0'
     commonsLangVersion = '3.5'
     confluentVersion = '3.2.1'
-    kafkaVersion = '0.10.1.0'
+    kafkaVersion = '1.0.1'
 
     /** tests **/
     junitVersion = '4.12'
@@ -14,7 +14,7 @@ ext {
     mockitoVersion = '1.10.19'
     hamcrestVersion = '1.3'
     commonsIoVersion = '2.5'
-    embeddedKafkaVersion = '1.1.2.RELEASE'
+    embeddedKafkaVersion = '2.1.7.RELEASE'
 }
 
 buildscript {

--- a/src/main/java/com/azimo/kafka/to/avro/writer/KafkaToAvroWriterApp.java
+++ b/src/main/java/com/azimo/kafka/to/avro/writer/KafkaToAvroWriterApp.java
@@ -29,7 +29,6 @@ public class KafkaToAvroWriterApp {
                 .schemaRegistryUrl(options.getSchemaRegistryUrl())
                 .offsetReset(options.getOffsetReset())
                 .consumerGroupId(options.getConsumerGroupId())
-                .isEnableAutoCommit(options.isEnableAutoCommit())
                 .build();
 
                 PCollection<AvroGenericRecord> records = p.apply(readKafkaTr)

--- a/src/main/java/com/azimo/kafka/to/avro/writer/config/KafkaToAvroWriterPipelineOptions.java
+++ b/src/main/java/com/azimo/kafka/to/avro/writer/config/KafkaToAvroWriterPipelineOptions.java
@@ -45,10 +45,4 @@ public interface KafkaToAvroWriterPipelineOptions extends DataflowPipelineOption
 	@Description("Kafka - a unique string that identifies the consumer group this consumer belongs to")
 	String getConsumerGroupId();
 	void setConsumerGroupId(String value);
-
-	@Description("Kafka - if set to true offsets are committed automatically with a frequency controlled by the config auto.commit.interval.ms (default 5000).")
-	@Default.Boolean(true)
-	boolean isEnableAutoCommit();
-	void setEnableAutoCommit(boolean value);
-
 }

--- a/src/main/java/com/azimo/kafka/to/avro/writer/read/ReadKafkaGenericTr.java
+++ b/src/main/java/com/azimo/kafka/to/avro/writer/read/ReadKafkaGenericTr.java
@@ -27,7 +27,6 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 	private String offsetReset;
 	private String consumerGroupId;
 	private long maxNumRecords;
-	private boolean isEnableAutoCommit;
 
 	private ReadKafkaGenericTr(Builder builder) {
 		this.inputTopics = builder.inputTopics;
@@ -36,7 +35,6 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 		this.offsetReset = builder.offsetReset;
 		this.consumerGroupId = builder.consumerGroupId;
 		this.maxNumRecords = builder.maxNumRecords;
-		this.isEnableAutoCommit = builder.isEnableAutoCommit;
 	}
 
     public static Builder newReadKafkaGenericTrBuilder() {
@@ -60,6 +58,7 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 				.withKeyDeserializer(StringDeserializer.class)
 				.withValueDeserializerAndCoder(BeamKafkaAvroGenericDeserializer.class, AvroGenericCoder.of(schemaRegistryUrl))
 				.withMaxNumRecords(maxNumRecords)
+				.commitOffsetsInFinalize()
 				.withoutMetadata();
 	}
 
@@ -68,7 +67,6 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 		configUpdates.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
 		configUpdates.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset);
 		configUpdates.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
-		configUpdates.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, isEnableAutoCommit);
 		return configUpdates;
 	}
 
@@ -79,7 +77,6 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 		private String offsetReset;
 		private String consumerGroupId;
 		private long maxNumRecords = Long.MAX_VALUE;
-        private boolean isEnableAutoCommit;
 
         private Builder() {
 		}
@@ -115,11 +112,6 @@ public class ReadKafkaGenericTr extends PTransform<PBegin, PCollection<AvroGener
 
 		public Builder maxNumRecords(long maxNumRecords) {
 			this.maxNumRecords = maxNumRecords;
-			return this;
-		}
-
-		public Builder isEnableAutoCommit(boolean isEnableAutoCommit) {
-			this.isEnableAutoCommit = isEnableAutoCommit;
 			return this;
 		}
 	}

--- a/src/main/java/com/azimo/kafka/to/avro/writer/write/DynamicAvroGenericRecordDestinations.java
+++ b/src/main/java/com/azimo/kafka/to/avro/writer/write/DynamicAvroGenericRecordDestinations.java
@@ -48,7 +48,7 @@ public class DynamicAvroGenericRecordDestinations extends DynamicAvroDestination
 
     @Override
     public AvroDestination getDefaultDestination() {
-        throw new RuntimeException("Default destination not supported");
+        return new AvroDestination();
     }
 
     @Override

--- a/src/test/java/com/azimo/kafka/to/avro/writer/read/ReadKafkaGenericTrTest.java
+++ b/src/test/java/com/azimo/kafka/to/avro/writer/read/ReadKafkaGenericTrTest.java
@@ -5,11 +5,11 @@ import com.azimo.kafka.to.avro.writer.serialize.AvroGenericRecord;
 import com.azimo.kafka.to.avro.writer.util.SchemaRegistryMockUtil;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.Lists;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.repackaged.com.google.common.collect.Lists;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.PCollection;
@@ -82,7 +82,6 @@ public class ReadKafkaGenericTrTest {
 				.schemaRegistryUrl(schemaRegistryUrl)
 				.offsetReset("earliest")
 				.consumerGroupId("testgroup")
-				.isEnableAutoCommit(false)
 				.maxNumRecords(expectedOutput.size())
 				.build();
 	}


### PR DESCRIPTION
Beam upgrade to 2.5.0 & switching kafkaio to commit offsets in finalise instead of autocommit (support added in beam 2.4)